### PR TITLE
add CodeIterator to execute code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,40 @@ pub enum Operation {
 pub mod json;
 pub mod operators;
 pub mod state;
+
+pub struct CodeIterator<'a> {
+	pub state: &'a mut state::InternalState,
+	pub operations: Vec<Operation>,
+	has_errored: bool
+}
+
+impl<'a> CodeIterator<'a> {
+	pub fn new(_state: &'a mut state::InternalState, _operations: Vec<Operation>) -> Self {
+		CodeIterator{state: _state, operations: _operations, has_errored: false}
+	}
+}
+
+impl<'a> Iterator for CodeIterator<'a> {
+	type Item = Result<(), String>;
+
+	fn next(&mut self) -> Option<Self::Item> {
+		if self.has_errored {
+			None
+		}
+		else if self.state.instruction_counter < self.operations.len() {
+			let _operation = self.operations[self.state.instruction_counter];
+			println!("applying operation {:?}", _operation);
+
+			let result = self.state.apply(_operation);
+
+			if result.is_err() {
+				self.has_errored = true;
+			}
+
+			Some(result)
+		}
+		else {
+			None
+		}
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,13 @@ impl<'a> Iterator for CodeIterator<'a> {
 			let result = self.state.apply(_operation);
 
 			if result.is_err() {
-				self.has_errored = true;
+				if let Operation::Inbox =  _operation {
+					self.has_errored = false;
+					return None;
+				}
+				else {
+					self.has_errored = true;
+				}
 			}
 
 			Some(result)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ extern crate clap;
 
 extern crate hrm_interpreter;
 use hrm_interpreter::json::{read_file, read_config};
+use hrm_interpreter::CodeIterator;
 use clap::{Arg, App};
 
 fn main() {
@@ -25,26 +26,6 @@ fn main() {
     let code = read_file(String::from(srcpath));
     // create the state to be modified
     let mut internal_state = read_config(String::from(inputpath));
-
-		loop {
-			if internal_state.instruction_counter < code.len() {
-				let _operation = code[internal_state.instruction_counter];
-				println!("applying operation {:?}", _operation);
-
-				let result = internal_state.apply(_operation);
-				if result.is_err() {
-					let reason = result.err().unwrap();
-					println!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-					println!("Error: {}", reason);
-					println!("Dumping current internal state:");
-					println!("{:?}", internal_state);
-					break;
-				}
-			}
-			else {
-				break;
-			}
-		}
 
 		let mut errored = false;
 		let mut reason = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,27 @@ fn main() {
 			}
 		}
 
-		// print internal state
-		println!("{:?}", internal_state);
+		let mut errored = false;
+		let mut reason = String::new();
+		{
+			let x = CodeIterator::new(&mut internal_state, code);
+
+			for operation_result in x {
+				if operation_result.is_err() {
+					errored = true;
+					reason = operation_result.err().unwrap();
+					break;
+				}
+			}
+		}
+
+		if errored {
+			println!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+			println!("Error: {}", reason);
+			println!("Dumping current internal state:");
+			println!("{:?}", internal_state);
+		}
+		else {
+			println!("{:?}", internal_state);
+		}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,9 @@ fn main() {
 		let mut errored = false;
 		let mut reason = String::new();
 		{
-			let x = CodeIterator::new(&mut internal_state, code);
+			let code_execution = CodeIterator::new(&mut internal_state, code);
 
-			for operation_result in x {
+			for operation_result in code_execution {
 				if operation_result.is_err() {
 					errored = true;
 					reason = operation_result.err().unwrap();


### PR DESCRIPTION
this PR introduces CodeIterator, an iterator that executes every operation.
Essentially, it hides the complexity of code execution in a simple iterator that main can use
with less knowledge of the internals.

It also lets us introduce a "non-error stop" behavior when an Inbox operation fails, hiding this fact from the user. This new behavior will be useful when hrm-interpreter will be used inside scripts/for integration testing stuff.