### PR TITLE
Add address support to HRMi

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -39,7 +39,8 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
         return Operation::Add{cell: Location::Cell(cell_to_add as usize)};
     }
     else if json_op.operation == String::from("copyfrom") {
-        return Operation::CopyFrom{cell: json_op.operand.unwrap().parse::<usize>().unwrap()};
+        let cell = json_op.operand.unwrap().parse::<usize>().unwrap();
+        return Operation::CopyFrom{cell: Location::Cell(cell)};
     }
     else if json_op.operation == String::from("copyto") {
         return Operation::CopyTo{cell: json_op.operand.unwrap().parse::<usize>().unwrap()};

--- a/src/json.rs
+++ b/src/json.rs
@@ -43,7 +43,8 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
         return Operation::CopyFrom{cell: Location::Cell(cell)};
     }
     else if json_op.operation == String::from("copyto") {
-        return Operation::CopyTo{cell: json_op.operand.unwrap().parse::<usize>().unwrap()};
+        let cell = json_op.operand.unwrap().parse::<usize>().unwrap();
+        return Operation::CopyTo{cell: Location::Cell(cell)};
     }
     else if json_op.operation == String::from("label") {
         return Operation::Label{};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub enum Operation {
 	Inbox,
 	Outbox,
 	Add{cell: Location},
-	CopyFrom{cell: usize},
+	CopyFrom{cell: Location},
 	CopyTo{cell: usize},
 	Label,
 	Jump{next_operation: usize},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,16 @@ pub enum Value {
 }
 
 #[derive(Debug, Clone, Copy)]
+pub enum Location {
+	Cell(usize),
+	Address(usize)
+}
+
+#[derive(Debug, Clone, Copy)]
 pub enum Operation {
 	Inbox,
 	Outbox,
-	Add{cell: usize},
+	Add{cell: Location},
 	CopyFrom{cell: usize},
 	CopyTo{cell: usize},
 	Label,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub enum Operation {
 	Outbox,
 	Add{cell: Location},
 	CopyFrom{cell: Location},
-	CopyTo{cell: usize},
+	CopyTo{cell: Location},
 	Label,
 	Jump{next_operation: usize},
 	JumpEqualsZero{next_operation: usize}

--- a/src/operators/add.rs
+++ b/src/operators/add.rs
@@ -1,18 +1,19 @@
 use operators::Operator;
 use Value;
+use Location;
 use state;
 // --
 use std::char;
 
 enum Error {
-	NoValue{cell: usize},
+	NoValue{cell: Location},
 	NoEmployeeValue,
 	SumOfChars,
 	SumOverflow{character: char, number: u32}
 }
 
 pub struct AddOp {
-	pub cell: usize
+	pub cell: Location
 }
 
 impl AddOp {
@@ -35,7 +36,8 @@ impl AddOp {
 
 	fn explain_error(e: Error) -> String {
 		match e {
-			Error::NoValue{cell: _cell} => format!("There is no value at cell {}", _cell),
+			Error::NoValue{cell: Location::Cell(_cell)} => format!("There is no value at cell {:?}", _cell),
+			Error::NoValue{cell: Location::Address(_cell)} => format!("There is no value at cell {:?}", _cell),
 			Error::NoEmployeeValue => String::from("the Employee register holds no value. Cannot add."),
 			Error::SumOfChars => String::from("cannot sum two characters!"),
 			Error::SumOverflow{character: _char, number: _num} =>
@@ -51,7 +53,11 @@ impl Operator for AddOp {
 	}
 
   fn apply_to(&self,  s: &mut state::InternalState) -> Result<(), String> {
-		let value_from_memory = s.memory[self.cell].clone();
+		let memory_position = match self.cell {
+			Location::Cell(mempos) => mempos,
+			Location::Address(mempos) => mempos
+		};
+		let value_from_memory = s.memory[memory_position].clone();
 		let res = match value_from_memory {
 			Some(ref v) => {
 				match s.register {
@@ -105,6 +111,7 @@ impl Operator for AddOp {
 mod test {
 	use state;
 	use Value;
+	use Location;
 	use Operation;
 	use operators::Operator;
 	use operators::add::AddOp;
@@ -118,7 +125,7 @@ mod test {
 			memory: vec!(Some(Value::Number{value: 4})),
 			instruction_counter: 0
 		};
-		let operation = AddOp{cell: 0};
+		let operation = AddOp{cell: Location::Cell(0)};
 
 		let _ = operation.apply_to(&mut state).unwrap();
 
@@ -137,7 +144,7 @@ mod test {
 			memory: vec!(None),
 			instruction_counter: 0
 		};
-		let operation = AddOp{cell: 0};
+		let operation = AddOp{cell: Location::Cell(0)};
 
 		let result = operation.apply_to(& mut state);
 
@@ -153,7 +160,7 @@ mod test {
 			memory: vec!(Some(Value::Number{value: 5})),
 			instruction_counter: 0
 		};
-		let operation = AddOp{cell: 0};
+		let operation = AddOp{cell: Location::Cell(0)};
 
 		let result = operation.apply_to(&mut state);
 
@@ -169,7 +176,7 @@ mod test {
 			memory: vec!(Some(Value::Character{value: 'a'})),
 			instruction_counter: 0
 		};
-		let operator = AddOp{cell: 0};
+		let operator = AddOp{cell: Location::Cell(0)};
 
 		let result = operator.apply_to(&mut state);
 
@@ -186,7 +193,7 @@ mod test {
 			instruction_counter: 0
 		};
 
-		let _ = state.apply(Operation::Add{cell: 0});
+		let _ = state.apply(Operation::Add{cell: Location::Cell(0)});
 
 		assert!(match state.register {
 			Some(Value::Character{value: 'f'}) => true,
@@ -203,7 +210,7 @@ mod test {
 			memory: vec!(Some(Value::Number{value: 5})),
 			instruction_counter: 0
 		};
-		let operation = AddOp{cell: 0};
+		let operation = AddOp{cell: Location::Cell(0)};
 
 		let result = operation.apply_to(&mut state);
 
@@ -220,7 +227,7 @@ mod test {
 			instruction_counter: 0
 		};
 
-		let _ = state.apply(Operation::Add{cell: 0}).unwrap();
+		let _ = state.apply(Operation::Add{cell: Location::Cell(0)}).unwrap();
 
 		assert!(match state.register {
 			Some(Value::Character{value: 'f'}) => true,
@@ -237,7 +244,7 @@ mod test {
 			memory: vec!(Some(Value::Character{value: 'z'})),
 			instruction_counter: 0
 		};
-		let operation = AddOp{cell: 0};
+		let operation = AddOp{cell: Location::Cell(0)};
 
 		let result = operation.apply_to(&mut state);
 

--- a/src/operators/copyfrom.rs
+++ b/src/operators/copyfrom.rs
@@ -1,19 +1,37 @@
 use operators::Operator;
 use state::InternalState;
+use Location;
+use Value;
 
 pub struct CopyFromOp {
-	pub cell: usize
+	pub cell: Location
 }
 impl Operator for CopyFromOp {
 	fn changes_instruction_counter(&self) -> bool { false }
 
 	fn apply_to(&self, s: &mut InternalState) -> Result<(), String> {
-		if let Some(_) = s.memory[self.cell] {
-			s.register = s.memory[self.cell];
+		let memory_position = match self.cell {
+			Location::Cell(mempos) => Ok(mempos as usize),
+			Location::Address(pointed_cell) => {
+				let pointed_value = s.memory[pointed_cell];
+				match pointed_value {
+					None => Err(format!("pointer cell is empty!")),
+					Some(Value::Number{value: addressed_cell}) => Ok(addressed_cell as usize),
+					Some(Value::Character{value: _}) => Err(format!("pointer cell contains a char"))
+				}
+			}
+		};
+		if let Err(error_reason) = memory_position {
+			return Err(error_reason);
+		}
+
+		let cell = memory_position.unwrap();
+		if let Some(_) = s.memory[cell] {
+			s.register = s.memory[cell];
 			Ok(())
 		}
 		else {
-			Err(format!("cell {} holds no value. could not copy a none value to the register", self.cell))
+			Err(format!("cell {} holds no value. could not copy a none value to the register", cell))
 		}
 	}
 }
@@ -22,6 +40,7 @@ impl Operator for CopyFromOp {
 mod test {
 	use state::InternalState;
   use Value;
+	use Location;
 	use operators::Operator;
 	use operators::copyfrom::CopyFromOp;
 
@@ -34,10 +53,24 @@ mod test {
 			output_tape: vec!(),
 			instruction_counter: 0
 		};
-		let operation = CopyFromOp{cell: 0};
+		let operation = CopyFromOp{cell: Location::Cell(0)};
 
 		let result = operation.apply_to(&mut state);
 
+		assert!(result.is_ok());
+		assert!(match state.register {
+			Some(Value::Number{value: 5}) => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn copyfrom_non_empty_addressed_cell(){
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(Some(Value::Number{value: 1}), Some(Value::Number{value:5}));
+		let operation = CopyFromOp{cell: Location::Address(0)};
+
+		let result = operation.apply_to(&mut state);
 		assert!(result.is_ok());
 		assert!(match state.register {
 			Some(Value::Number{value: 5}) => true,
@@ -54,12 +87,25 @@ mod test {
 			output_tape: vec!(),
 			instruction_counter: 0
 		};
-		let operation = CopyFromOp{cell: 0};
+		let operation = CopyFromOp{cell: Location::Cell(0)};
 
 		let result = operation.apply_to(&mut state);
 
 		assert!(result.is_err());
 	}
+
+	#[test]
+	fn copyfrom_empty_addressed_cell() {
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(Some(Value::Number{value: 1}), None);
+		let operation = CopyFromOp{cell: Location::Address(0)};
+
+		let result = operation.apply_to(&mut state);
+
+		println!("{:?}", result);
+		assert!(result.is_err());
+	}
+
 
 	#[test]
 	#[should_panic]
@@ -71,7 +117,18 @@ mod test {
 			output_tape: vec!(),
 			instruction_counter: 0
 		};
-		let operation = CopyFromOp{cell: 9};
+		let operation = CopyFromOp{cell: Location::Cell(9)};
+
+		// #[should_panic]
+		let _ = operation.apply_to(&mut state);
+	}
+
+	#[test]
+	#[should_panic]
+	fn copyfrom_non_existent_addressed_cell() {
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(Some(Value::Number{value: 9}));
+		let operation = CopyFromOp{cell: Location::Address(0)};
 
 		// #[should_panic]
 		let _ = operation.apply_to(&mut state);

--- a/src/operators/copyto.rs
+++ b/src/operators/copyto.rs
@@ -1,19 +1,34 @@
 use operators::Operator;
 use state::InternalState;
+use Location;
+use Value;
 
 pub struct CopyToOp {
-	pub cell: usize
+	pub cell: Location
 }
 impl Operator for CopyToOp {
 	fn changes_instruction_counter(&self) -> bool { false }
 
 	fn apply_to(&self, s: &mut InternalState) -> Result<(), String> {
+		let memory_position = match self.cell {
+			Location::Cell(mempos) => Ok(mempos),
+			Location::Address(addressed_cell) => match s.memory[addressed_cell] {
+				None => Err(format!("cannot read the value of the addressed cell")),
+				Some(Value::Character{value: _}) => Err(format!("char is not a valid address")),
+				Some(Value::Number{value: mempos}) => Ok(mempos as usize)
+			}
+		};
+		if let Err(error_reason) = memory_position {
+			return Err(error_reason);
+		}
+
+		let cell = memory_position.unwrap();
 		if let Some(value) = s.register {
-			s.memory[self.cell] = Some(value);
+			s.memory[cell] = Some(value);
 			Ok(())
 		}
 		else {
-			Err(format!("register holds no value. could not copy a None value to {}", self.cell))
+			Err(format!("register holds no value. could not copy a None value to {}", cell))
 		}
 	}
 }


### PR DESCRIPTION
in HRM jargon, "address" is the same concept of C "pointer", even though they're usually used to implement array indexes.

Addresses are introduced at 2/3 of the game, and enable difficult problems that require players to implement [sorting algorithms](https://github.com/alfateam123/hrm-compiler/blob/master/examples/script_41.hrm), or other algorithms that require to access cells that are not known at compile time-.

This MR adds support for addresses to the interpreter
* implement address-specific logic in add, copyfrom and copyto
* rework json format for "code" files: cells, addresses and labels are now tagged