### PR TITLE
Add missing operations (bump+, bump-, sub, jneg)

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -82,6 +82,22 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
         };
         return Operation::CopyTo{cell: cell};
     }
+    else if json_op.operation == String::from("bump+") {
+        let cell = match json_op.operand.unwrap() {
+            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'copyto'"),
+            JsonOperand::Address(cell) => Location::Address(cell as usize),
+            JsonOperand::Cell(cell) => Location::Cell(cell as usize)
+        };
+        return Operation::BumpPlus{cell: cell};
+    }
+    else if json_op.operation == String::from("bump-") {
+        let cell = match json_op.operand.unwrap() {
+            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'copyto'"),
+            JsonOperand::Address(cell) => Location::Address(cell as usize),
+            JsonOperand::Cell(cell) => Location::Cell(cell as usize)
+        };
+        return Operation::BumpMinus{cell: cell};
+    }
     else if json_op.operation == String::from("label") {
         return Operation::Label{};
     }
@@ -94,13 +110,22 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
             panic!("only Labels are valid operands for jmp");
         }
     }
+    else if json_op.operation == String::from("jneg") {
+        if let JsonOperand::Label(label_name) = json_op.operand.unwrap() {
+            let next_position = position_from_label(&label_name, &labels_mapping).unwrap();
+            return Operation::JumpNegative{next_operation: next_position};
+        }
+        else {
+            panic!("only Labels are valid operands for jneg");
+        }
+    }
     else if json_op.operation == String::from("jez") {
         if let JsonOperand::Label(label_name) = json_op.operand.unwrap() {
             let next_position = position_from_label(&label_name, &labels_mapping).unwrap();
             return Operation::JumpEqualsZero{next_operation: next_position};
         }
         else {
-            panic!("only Labels are valid operands for jmp");
+            panic!("only Labels are valid operands for jez");
         }
     }
     else if json_op.operation == String::from("outbox") { return Operation::Outbox{}; }

--- a/src/json.rs
+++ b/src/json.rs
@@ -29,7 +29,7 @@ pub struct JsonOperation {
 #[derive(Deserialize, Clone)]
 #[serde(untagged)]
 enum JsonValue {
-    Number(u32),
+    Number(i32),
     Character(char)
 }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -58,6 +58,14 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
         };
         return Operation::Add{cell: cell_to_add};
     }
+    else if json_op.operation == String::from("sub") {
+        let cell_to_sub = match json_op.operand.unwrap() {
+            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'add'"),
+            JsonOperand::Address(cell) => Location::Address(cell as usize),
+            JsonOperand::Cell(cell) => Location::Cell(cell as usize)
+        };
+        return Operation::Sub{cell: cell_to_sub};
+    }
     else if json_op.operation == String::from("copyfrom") {
         let cell = match json_op.operand.unwrap() {
             JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'copyfrom'"),

--- a/src/json.rs
+++ b/src/json.rs
@@ -60,7 +60,7 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
     }
     else if json_op.operation == String::from("sub") {
         let cell_to_sub = match json_op.operand.unwrap() {
-            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'add'"),
+            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'sub'"),
             JsonOperand::Address(cell) => Location::Address(cell as usize),
             JsonOperand::Cell(cell) => Location::Cell(cell as usize)
         };
@@ -84,7 +84,7 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
     }
     else if json_op.operation == String::from("bump+") {
         let cell = match json_op.operand.unwrap() {
-            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'copyto'"),
+            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'bump+'"),
             JsonOperand::Address(cell) => Location::Address(cell as usize),
             JsonOperand::Cell(cell) => Location::Cell(cell as usize)
         };
@@ -92,7 +92,7 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
     }
     else if json_op.operation == String::from("bump-") {
         let cell = match json_op.operand.unwrap() {
-            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'copyto'"),
+            JsonOperand::Label(_) => panic!("only Address or Cell are valid operand for 'bump-'"),
             JsonOperand::Address(cell) => Location::Address(cell as usize),
             JsonOperand::Cell(cell) => Location::Cell(cell as usize)
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub enum Operation {
 	Inbox,
 	Outbox,
 	Add{cell: Location},
+	Sub{cell: Location},
 	CopyFrom{cell: Location},
 	CopyTo{cell: Location},
 	Label,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ extern crate serde_json;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Value {
-	Number{value: u32},
+	Number{value: i32},
 	Character{value: char}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,10 @@ pub enum Operation {
 	CopyTo{cell: Location},
 	Label,
 	Jump{next_operation: usize},
-	JumpEqualsZero{next_operation: usize}
+	JumpEqualsZero{next_operation: usize},
+	JumpNegative{next_operation: usize},
+	BumpPlus{cell: Location},
+	BumpMinus{cell: Location},
 }
 
 pub mod json;

--- a/src/operators/add.rs
+++ b/src/operators/add.rs
@@ -10,7 +10,7 @@ enum Error {
 	PointerCellContainsChar,
 	NoEmployeeValue,
 	SumOfChars,
-	SumOverflow{character: char, number: u32}
+	SumOverflow{character: char, number: i32}
 }
 
 pub struct AddOp {
@@ -18,20 +18,20 @@ pub struct AddOp {
 }
 
 impl AddOp {
-	fn add_number_and_char(num: u32, c: char) -> Result<char, u32> {
+	fn add_number_and_char(num: i32, c: char) -> Result<char, i32> {
 		const ALPHABET_RADIX: u32 = 36;
-		const SMALL_ASCII_A: u32 = 97;
-		const HEX_A_IN_DEC: u32 = 10;
+		const SMALL_ASCII_A: i32 = 97;
+		const HEX_A_IN_DEC: i32 = 10;
 
-		let c_as_number = c.to_digit(ALPHABET_RADIX).unwrap();
+		let c_as_number = c.to_digit(ALPHABET_RADIX).unwrap() as i32;
 		let new_number = c_as_number + num;
-		let fixed_for_char: u32 = SMALL_ASCII_A + (new_number - HEX_A_IN_DEC);
+		let fixed_for_char: i32 = SMALL_ASCII_A + (new_number - HEX_A_IN_DEC);
 
-		if new_number >= 36 {
+		if new_number < 0 || new_number >= 36 {
 			Err(new_number)
 		}
 		else {
-			Ok(char::from_u32(fixed_for_char).unwrap())
+			Ok(char::from_u32(fixed_for_char as u32).unwrap())
 		}
 	}
 

--- a/src/operators/bump.rs
+++ b/src/operators/bump.rs
@@ -23,11 +23,11 @@ impl BumpOp {
 }
 
 pub struct BumpPlusOp {
-	cell: Location
+	pub cell: Location
 }
 
 pub struct BumpMinusOp {
-	cell: Location
+	pub cell: Location
 }
 
 impl Operator for BumpPlusOp {

--- a/src/operators/bump.rs
+++ b/src/operators/bump.rs
@@ -26,6 +26,10 @@ pub struct BumpPlusOp {
 	cell: Location
 }
 
+pub struct BumpMinusOp {
+	cell: Location
+}
+
 impl Operator for BumpPlusOp {
 	fn changes_instruction_counter(&self) -> bool { false }
 
@@ -61,6 +65,42 @@ impl Operator for BumpPlusOp {
 	}
 }
 
+impl Operator for BumpMinusOp {
+	fn changes_instruction_counter(&self) -> bool { false }
+
+	fn apply_to(&self, s: &mut InternalState) -> Result<(), String> {
+		let memory_position = match self.cell {
+			Location::Cell(mempos) => Ok(mempos),
+			Location::Address(mempos) => {
+				let value_from_memory = s.memory[mempos].clone();
+				match value_from_memory {
+					Some(Value::Number{value: pointed_cell}) => Ok(pointed_cell as usize),
+					Some(Value::Character{value: _}) => Err(BumpOp::explain_error(Error::PointerCellContainsChar)),
+					None => Err(BumpOp::explain_error(Error::NoValue{cell: Location::Cell(mempos)}))
+				}
+			}
+		};
+		if let Err(error_message) = memory_position {
+			return Err(error_message);
+		}
+
+		let mempos = memory_position.unwrap();
+		let data = s.memory[mempos];
+		match data {
+			None => Err(BumpOp::explain_error(Error::NoValue{cell: Location::Cell(mempos)})),
+			Some(Value::Number{value: _num}) => {
+				s.memory[mempos] = Some(Value::Number{value: _num-1});
+				s.register = s.memory[mempos];
+				Ok(())
+			},
+			Some(Value::Character{value: _char}) =>
+				Err(BumpOp::explain_error(Error::BumpChar{value: _char}))
+		}
+
+	}
+}
+
+
 #[cfg(test)]
 mod test {
 	use Value;
@@ -68,6 +108,7 @@ mod test {
 	use state::InternalState;
 	use operators::Operator;
 	use operators::bump::BumpPlusOp;
+	use operators::bump::BumpMinusOp;
 
 	#[test]
 	fn bumpplus_number() {
@@ -114,4 +155,51 @@ mod test {
 			_ => false
 		});
 	}
+
+	#[test]
+	fn bumpminus_number() {
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(Some(Value::Number{value: 0}));
+
+		let result = BumpMinusOp{cell: Location::Cell(0)}.apply_to(&mut state);
+
+		assert!(result.is_ok());
+		assert!(match state.memory[0] {
+			Some(Value::Number{value: -1}) => true,
+			_ => false
+		});
+		assert!(match state.register {
+			Some(Value::Number{value: -1}) => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn bumpminus_char() {
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(Some(Value::Character{value: 'a'}));
+
+		let result = BumpMinusOp{cell: Location::Cell(0)}.apply_to(&mut state);
+
+		assert!(result.is_err());
+		assert!(match state.register {
+			None => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn bumpminus_none() {
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(None);
+
+		let result = BumpMinusOp{cell: Location::Cell(0)}.apply_to(&mut state);
+
+		assert!(result.is_err());
+		assert!(match state.register {
+			None => true,
+			_ => false
+		});
+	}
+
 }

--- a/src/operators/bump.rs
+++ b/src/operators/bump.rs
@@ -1,0 +1,117 @@
+use operators::Operator;
+use state::InternalState;
+use Value;
+use Location;
+
+enum Error {
+	PointerCellContainsChar,
+	NoValue{cell: Location},
+	BumpChar{value: char}
+}
+
+struct BumpOp {}
+
+impl BumpOp {
+	fn explain_error(error: Error) -> String {
+		match error {
+			Error::NoValue{cell: Location::Cell(_cell)} => format!("There is no value at cell {:?}", _cell),
+			Error::NoValue{cell: Location::Address(_cell)} => format!("There is no value at cell {:?}", _cell),
+			Error::BumpChar{value: _char} => format!("Cannot bump char {:?}", _char),
+			Error::PointerCellContainsChar => String::from("The selected cell should contain a number, not a char")
+		}
+	}
+}
+
+pub struct BumpPlusOp {
+	cell: Location
+}
+
+impl Operator for BumpPlusOp {
+	fn changes_instruction_counter(&self) -> bool { false }
+
+	fn apply_to(&self, s: &mut InternalState) -> Result<(), String> {
+		let memory_position = match self.cell {
+			Location::Cell(mempos) => Ok(mempos),
+			Location::Address(mempos) => {
+				let value_from_memory = s.memory[mempos].clone();
+				match value_from_memory {
+					Some(Value::Number{value: pointed_cell}) => Ok(pointed_cell as usize),
+					Some(Value::Character{value: _}) => Err(BumpOp::explain_error(Error::PointerCellContainsChar)),
+					None => Err(BumpOp::explain_error(Error::NoValue{cell: Location::Cell(mempos)}))
+				}
+			}
+		};
+		if let Err(error_message) = memory_position {
+			return Err(error_message);
+		}
+
+		let mempos = memory_position.unwrap();
+		let data = s.memory[mempos];
+		match data {
+			None => Err(BumpOp::explain_error(Error::NoValue{cell: Location::Cell(mempos)})),
+			Some(Value::Number{value: _num}) => {
+				s.memory[mempos] = Some(Value::Number{value: _num+1});
+				s.register = s.memory[mempos];
+				Ok(())
+			},
+			Some(Value::Character{value: _char}) =>
+				Err(BumpOp::explain_error(Error::BumpChar{value: _char}))
+		}
+
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use Value;
+	use Location;
+	use state::InternalState;
+	use operators::Operator;
+	use operators::bump::BumpPlusOp;
+
+	#[test]
+	fn bumpplus_number() {
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(Some(Value::Number{value: 0}));
+
+		let result = BumpPlusOp{cell: Location::Cell(0)}.apply_to(&mut state);
+
+		assert!(result.is_ok());
+		assert!(match state.memory[0] {
+			Some(Value::Number{value: 1}) => true,
+			_ => false
+		});
+		assert!(match state.register {
+			Some(Value::Number{value: 1}) => true,
+			_ => false
+		});
+	}
+	
+	#[test]
+	fn bumpplus_char() {
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(Some(Value::Character{value: 'a'}));
+
+		let result = BumpPlusOp{cell: Location::Cell(0)}.apply_to(&mut state);
+
+		assert!(result.is_err());
+		assert!(match state.register {
+			None => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn bumpplus_none() {
+		let mut state = InternalState::new(None, 0);
+		state.memory = vec!(None);
+
+		let result = BumpPlusOp{cell: Location::Cell(0)}.apply_to(&mut state);
+
+		assert!(result.is_err());
+		assert!(match state.register {
+			None => true,
+			_ => false
+		});
+	}
+}

--- a/src/operators/jump.rs
+++ b/src/operators/jump.rs
@@ -9,7 +9,7 @@ impl Operator for LabelOp {
     fn changes_instruction_counter(&self) -> bool { false }
 
     fn apply_to(&self, _: &mut state::InternalState) -> Result<(), String> {
-	Ok(())
+        Ok(())
     }
 }
 
@@ -23,7 +23,7 @@ impl Operator for JumpOp {
 
     fn apply_to(&self, s: &mut state::InternalState) -> Result<(), String> {
         s.instruction_counter = self.next_operation;
-	Ok(())
+        Ok(())
     }
 }
 
@@ -37,18 +37,40 @@ impl Operator for JumpEqualsZeroOp {
 
     fn apply_to(&self, s: &mut state::InternalState) -> Result<(), String> {
         match s.register {
-	    None => {
-	        Err(String::from("register holds no value! cannot compare it to zero!"))
-	    }
-	    Some(Value::Number{value: 0}) => {
-	        s.instruction_counter = self.next_operation;
-		Ok(())
-	    },
-	    _ => {
-	        s.instruction_counter += 1;
-		Ok(())
-	    }
-	}
+            None => Err(String::from("register holds no value! cannot compare it to zero!")),
+            Some(Value::Number{value: 0}) => {
+                s.instruction_counter = self.next_operation;
+                Ok(())
+            },
+            _ => {
+                s.instruction_counter += 1;
+                Ok(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct JumpNegativeOp {
+    pub next_operation: usize
+}
+
+impl Operator for JumpNegativeOp {
+    fn changes_instruction_counter(&self) -> bool { true }
+
+    fn apply_to(&self, s: &mut state::InternalState) -> Result<(), String> {
+        match s.register {
+            None => Err(String::from("register holds no value! cannot see if it is negative!")),
+            Some(Value::Character{value: _}) => Err(String::from("cannot compare a character to zero!")),
+            Some(Value::Number{value: _v}) if _v < 0 => {
+                s.instruction_counter = self.next_operation;
+                Ok(())
+            },
+            _ => {
+                s.instruction_counter += 1;
+                Ok(())
+            }
+        }
     }
 }
 
@@ -57,43 +79,82 @@ mod test {
     use operators::Operator;
     use operators::jump::LabelOp;
     use operators::jump::JumpEqualsZeroOp;
+    use operators::jump::JumpNegativeOp;
     use state::InternalState;
     use Value;
 
     #[test]
     fn label_does_not_change_instruction_counter() {
         let mut _state = InternalState::new(Some(Value::Number{value: 0}), 0);
-	let _op = LabelOp;
+        let _op = LabelOp;
 
         _op.apply_to(&mut _state).unwrap();
 
-	assert!(_state.instruction_counter == 0);
+        assert!(_state.instruction_counter == 0);
     }
 
     #[test]
     fn jez_register_is_zero() {
         let mut _state = InternalState::new(Some(Value::Number{value: 0}), 0);
-	let _op = JumpEqualsZeroOp{next_operation: 15};
+        let _op = JumpEqualsZeroOp{next_operation: 15};
 
         _op.apply_to(&mut _state).unwrap();
 
-	assert!(_state.instruction_counter == 15);
+        assert!(_state.instruction_counter == 15);
     }
 
     #[test]
     fn jez_register_not_zero() {
         let mut _state = InternalState::new(Some(Value::Number{value: 5}), 0);
-	let _op = JumpEqualsZeroOp{next_operation: 15};
+        let _op = JumpEqualsZeroOp{next_operation: 15};
 
         _op.apply_to(&mut _state).unwrap();
 
-	assert!(_state.instruction_counter == 1);
+        assert!(_state.instruction_counter == 1);
     }
 
     #[test]
     fn jez_no_register_value() {
         let mut _state = InternalState::new(None, 0);
-	let _op = JumpEqualsZeroOp{next_operation: 15};
+        let _op = JumpEqualsZeroOp{next_operation: 15};
+
+        assert!(_op.apply_to(&mut _state).is_err());
+    }
+
+    #[test]
+    fn jneg_register_is_zero() {
+        let mut _state = InternalState::new(Some(Value::Number{value: 0}), 0);
+        let _op = JumpNegativeOp{next_operation: 15};
+
+        _op.apply_to(&mut _state).unwrap();
+
+        assert!(_state.instruction_counter == 1);
+    }
+
+    #[test]
+    fn jneg_register_is_negative() {
+        let mut _state = InternalState::new(Some(Value::Number{value: -2}), 0);
+        let _op = JumpNegativeOp{next_operation: 15};
+
+        _op.apply_to(&mut _state).unwrap();
+
+        assert!(_state.instruction_counter == 15);
+    }
+
+    #[test]
+    fn jneg_register_is_positive() {
+        let mut _state = InternalState::new(Some(Value::Number{value: 5}), 0);
+        let _op = JumpEqualsZeroOp{next_operation: 15};
+
+        _op.apply_to(&mut _state).unwrap();
+
+        assert!(_state.instruction_counter == 1);
+    }
+
+    #[test]
+    fn jneg_no_register_value() {
+        let mut _state = InternalState::new(None, 0);
+        let _op = JumpEqualsZeroOp{next_operation: 15};
 
         assert!(_op.apply_to(&mut _state).is_err());
     }

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -15,3 +15,4 @@ pub mod outbox;
 pub mod copyfrom;
 pub mod copyto;
 pub mod jump;
+pub mod bump;

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -9,6 +9,7 @@ pub trait Operator {
 }
 
 pub mod add;
+pub mod sub;
 pub mod inbox;
 pub mod outbox;
 pub mod copyfrom;

--- a/src/operators/sub.rs
+++ b/src/operators/sub.rs
@@ -1,0 +1,384 @@
+use operators::Operator;
+use Value;
+use Location;
+use state;
+// --
+use std::char;
+
+enum Error {
+	NoValue{cell: Location},
+	PointerCellContainsChar,
+	NoEmployeeValue,
+	NumLessChar,
+	SubUnderflow{character: char, number: i32},
+	SubUnderflowOfChar{character: char, other_character: char}
+}
+
+pub struct SubOp {
+	pub cell: Location
+}
+
+impl SubOp {
+	fn sub_char_and_number(c: char, num: i32) -> Result<char, i32> {
+		const ALPHABET_RADIX: u32 = 36;
+		const SMALL_ASCII_A: i32 = 97;
+		const HEX_A_IN_DEC: i32 = 10;
+
+		let c_as_number = c.to_digit(ALPHABET_RADIX).unwrap() as i32;
+		if num < c_as_number {
+			Err(num - c_as_number)
+		}
+		else {
+			let new_number = num - c_as_number;
+			let fixed_for_char: u32 = (SMALL_ASCII_A - (new_number - HEX_A_IN_DEC)) as u32;
+
+			Ok(char::from_u32(fixed_for_char).unwrap())
+		}
+	}
+
+	fn sub_char_and_char(a: char, b: char) -> Result<i32, i32> {
+		const ALPHABET_RADIX: u32 = 36;
+
+		let a_as_number = a.to_digit(ALPHABET_RADIX).unwrap() as i32;
+		let b_as_number = b.to_digit(ALPHABET_RADIX).unwrap() as i32;
+		let new_number = b_as_number - a_as_number;
+		Ok(new_number)
+	}
+
+	fn explain_error(e: Error) -> String {
+		match e {
+			Error::NoValue{cell: Location::Cell(_cell)} => format!("There is no value at cell {:?}", _cell),
+			Error::NoValue{cell: Location::Address(_cell)} => format!("There is no value at cell {:?}", _cell),
+			Error::PointerCellContainsChar => String::from("The selected cell should contain a number, not a char"),
+			Error::NoEmployeeValue => String::from("the Employee register holds no value. Cannot add."),
+			Error::NumLessChar => String::from("cannot perform <num> - <char>"),
+			Error::SubUnderflow{character: _char, number: _num} =>
+				format!("value underflowed! {} - {} is not representable as a letter!",
+								_char, _num),
+			Error::SubUnderflowOfChar{character: _char, other_character: _num} =>
+				format!("value underflowed! {} - {} is not representable as a letter!",
+								_char, _num)
+		}
+	}
+}
+
+impl Operator for SubOp {
+  fn changes_instruction_counter(&self) -> bool {
+		false
+	}
+
+  fn apply_to(&self,  s: &mut state::InternalState) -> Result<(), String> {
+		let memory_position = match self.cell {
+			Location::Cell(mempos) => Ok(mempos),
+			Location::Address(mempos) => {
+				let value_from_memory = s.memory[mempos].clone();
+				match value_from_memory {
+					Some(Value::Number{value: pointed_cell}) => Ok(pointed_cell as usize),
+					Some(Value::Character{value: _}) => Err(SubOp::explain_error(Error::PointerCellContainsChar)),
+					None => Err(SubOp::explain_error(Error::NoValue{cell: Location::Cell(mempos)}))
+				}
+			}
+		};
+		if let Err(error_message) = memory_position {
+			return Err(error_message);
+		}
+
+		let value_from_memory = s.memory[memory_position.unwrap()].clone();
+		let res = match value_from_memory {
+			Some(ref v) => {
+				match s.register {
+					Some(old_register) => {
+						let new_register_value: Result<Value, String> =  match (v, old_register) {
+							(&Value::Number{value: _v}, Value::Number{value: _old}) => {
+								Ok(Value::Number{value: _v - _old})
+							},
+							(&Value::Character{value: _v}, Value::Character{value: _old}) => {
+								if let Ok(new_number) = SubOp::sub_char_and_char(_v, _old) {
+									Ok(Value::Number{value: new_number})
+								}
+								else {
+									Err(SubOp::explain_error(Error::SubUnderflowOfChar{character: _old, other_character: _v}))
+								}
+							},
+							(&Value::Character{value: _v}, Value::Number{value: _old}) => {
+								if let Ok(new_char) = SubOp::sub_char_and_number(_v, _old) {
+									Ok(Value::Character{value: new_char})
+								}
+								else {
+									Err(SubOp::explain_error(Error::SubUnderflow{character: _v, number: _old}))
+								}
+							},
+							(&Value::Number{value: _v}, Value::Character{value: _old}) =>
+								Err(SubOp::explain_error(Error::NumLessChar))
+						};
+						
+						match new_register_value {
+							Ok(value) => {
+								s.register = Some(value);
+								Ok(())
+							},
+							Err(reason) => Err(reason)
+						}
+					}
+					_ => {
+						Err(SubOp::explain_error(Error::NoEmployeeValue))
+					}
+				}
+			}
+			_ => {
+				Err(SubOp::explain_error(Error::NoValue{cell: self.cell}))
+			}
+		};
+
+		res
+  }
+}
+
+#[cfg(test)]
+mod test {
+	use state;
+	use Value;
+	use Location;
+	use Operation;
+	use operators::Operator;
+	use operators::sub::SubOp;
+
+	#[test]
+	fn sub_two_numbers(){
+		let mut state = state::InternalState {
+			register: Some(Value::Number{value: 4}),
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Number{value: 5})),
+			instruction_counter: 0
+		};
+		let operation = SubOp{cell: Location::Cell(0)};
+
+		let _ = operation.apply_to(&mut state).unwrap();
+
+		assert!(match state.register {
+			Some(Value::Number{value: 1}) => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn sub_two_numbers_negative_result(){
+		let mut state = state::InternalState {
+			register: Some(Value::Number{value: 5}),
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Number{value: 4})),
+			instruction_counter: 0
+		};
+		let operation = SubOp{cell: Location::Cell(0)};
+
+		let _ = operation.apply_to(&mut state).unwrap();
+
+		assert!(match state.register {
+			Some(Value::Number{value: -1}) => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn sub_two_numbers_address() {
+		let mut state = state::InternalState::new(Some(Value::Number{value: 4}), 0);
+		state.memory = vec!(Some(Value::Number{value: 1}), Some(Value::Number{value: 5}));
+		let operation = SubOp{cell: Location::Address(0)};
+
+		let _ = operation.apply_to(&mut state).unwrap();
+
+		assert!(match state.register {
+			Some(Value::Number{value: 1}) => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn sub_two_numbers_address_negative_result() {
+		let mut state = state::InternalState::new(Some(Value::Number{value: 5}), 0);
+		state.memory = vec!(Some(Value::Number{value: 1}), Some(Value::Number{value: 4}));
+		let operation = SubOp{cell: Location::Address(0)};
+
+		let _ = operation.apply_to(&mut state).unwrap();
+
+		assert!(match state.register {
+			Some(Value::Number{value: -1}) => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn sub_number_to_empty_cell(){
+		let mut state = state::InternalState {
+			register: Some(Value::Number{value: 5}),
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(None),
+			instruction_counter: 0
+		};
+		let operation = SubOp{cell: Location::Cell(0)};
+
+		let result = operation.apply_to(& mut state);
+
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_two_numbers_to_empty_address() {
+		let mut state = state::InternalState::new(Some(Value::Number{value: 5}), 0);
+		state.memory = vec!(None, Some(Value::Number{value: 4}));
+		let operation = SubOp{cell: Location::Address(0)};
+
+		let result = operation.apply_to(&mut state);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_number_to_empty_addressed_cell(){
+		let mut state = state::InternalState::new(Some(Value::Number{value: 5}), 0);
+		state.memory = vec!(Some(Value::Number{value: 1}), None, None, None, None);
+		let operation = SubOp{cell: Location::Address(0)};
+
+		let result = operation.apply_to(&mut state);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_number_to_empty_register(){
+		let mut state = state::InternalState {
+			register: None,
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Number{value: 5})),
+			instruction_counter: 0
+		};
+		let operation = SubOp{cell: Location::Cell(0)};
+
+		let result = operation.apply_to(&mut state);
+
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_addressed_number_to_empty_register(){
+		let mut state = state::InternalState {
+			register: None,
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Number{value: 1}), Some(Value::Number{value: 5})),
+			instruction_counter: 0
+		};
+		let operation = SubOp{cell: Location::Address(0)};
+
+		let result = operation.apply_to(&mut state);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_char_to_char(){
+		let mut state = state::InternalState {
+			register: Some(Value::Character{value: 'a'}),
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Character{value: 'a'})),
+			instruction_counter: 0
+		};
+		let operator = SubOp{cell: Location::Cell(0)};
+
+		let result = operator.apply_to(&mut state);
+
+		assert!(result.is_ok());
+		assert!(match state.register {
+			Some(Value::Number{value: 0}) => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn sub_char_to_addressed_char(){
+		let mut state = state::InternalState::new(Some(Value::Character{value: 'a'}), 0);
+		state.memory = vec!(Some(Value::Number{value: 1}), Some(Value::Character{value: 'a'}));
+		let operator = SubOp{cell: Location::Address(0)};
+
+		let result = operator.apply_to(&mut state);
+
+		assert!(result.is_ok());
+		assert!(match state.register {
+			Some(Value::Number{value: 0}) => true,
+			_ => false
+		});
+	}
+
+	#[test]
+	fn sub_char_to_number(){
+		let mut state = state::InternalState {
+			register: Some(Value::Character{value: 'a'}),
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Number{value: 5})),
+			instruction_counter: 0
+		};
+
+		let result = state.apply(Operation::Sub{cell: Location::Cell(0)});
+
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_char_to_number_overflow(){
+		let mut state = state::InternalState {
+			register: Some(Value::Character{value: 'z'}),
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Number{value: 5})),
+			instruction_counter: 0
+		};
+		let operation = SubOp{cell: Location::Cell(0)};
+
+		let result = operation.apply_to(&mut state);
+
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_number_to_char(){
+		let mut state = state::InternalState {
+			register: Some(Value::Number{value: 5}),
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Character{value: 'a'})),
+			instruction_counter: 0
+		};
+
+		let result = state.apply(Operation::Sub{cell: Location::Cell(0)});
+
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_number_to_addressed_char(){
+		let mut state = state::InternalState::new(Some(Value::Number{value: 5}), 0);
+		state.memory = vec!(Some(Value::Number{value: 1}), Some(Value::Character{value: 'a'}));
+
+		let result = state.apply(Operation::Sub{cell: Location::Address(0)});
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn sub_number_to_char_overflow(){
+		let mut state = state::InternalState {
+			register: Some(Value::Number{value: 5}),
+			input_tape: vec!(),
+			output_tape: vec!(),
+			memory: vec!(Some(Value::Character{value: 'z'})),
+			instruction_counter: 0
+		};
+		let operation = SubOp{cell: Location::Cell(0)};
+
+		let result = operation.apply_to(&mut state);
+
+		assert!(result.is_err());
+	}
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -48,6 +48,9 @@ impl InternalState {
 			Operation::Add{cell: _cell} => {
 				apply_operation!(self, operators::add::AddOp{cell: _cell})
 			},
+			Operation::Sub{cell: _cell} => {
+				apply_operation!(self, operators::sub::SubOp{cell: _cell})
+			},
 			Operation::Inbox => {
 				apply_operation!(self, operators::inbox::InboxOp{})
 			},

--- a/src/state.rs
+++ b/src/state.rs
@@ -72,7 +72,15 @@ impl InternalState {
 			Operation::JumpEqualsZero{next_operation: _next_op} => {
 				apply_operation!(self, operators::jump::JumpEqualsZeroOp{next_operation: _next_op})
 			}
-
+			Operation::JumpNegative{next_operation: _next_op} => {
+				apply_operation!(self, operators::jump::JumpNegativeOp{next_operation: _next_op})
+			}
+			Operation::BumpPlus{cell: _cell} => {
+				apply_operation!(self, operators::bump::BumpPlusOp{cell: _cell})
+			}
+			Operation::BumpMinus{cell: _cell} => {
+				apply_operation!(self, operators::bump::BumpMinusOp{cell: _cell})
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the following operations to the interpreter
* `bump+` (increment)
* `bump-` (decrement)
* `sub` (subtraction)
* `jneg` (jump if negative)

To enable `sub`, `jneg` and `bump-` to work, Value::Number now takes an `i32` instead
of `u32`: unsigned values can only represent non-negative values.