### PR TITLE
dump internal state and error message (if any) in json file at end of execution

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -201,10 +201,23 @@ pub fn read_config(path: String) -> InternalState  {
     };
 }
 
-pub fn dump_state(internal_state: &InternalState) {
-    let raw_state = serde_json::to_string(&internal_state).unwrap();
+#[derive(Serialize)]
+struct StateDump {
+    internal_state: InternalState,
+    ended_with_error: bool,
+    error_reason: String
+}
 
-    let mut file = File::create("state_dump.json").unwrap();
+pub fn dump_state(internal_state: &InternalState, srcpath: &str, error_reason: String) {
+    let state_dump = StateDump {
+        internal_state: internal_state.clone(),
+        ended_with_error: !error_reason.is_empty(),
+        error_reason: error_reason
+    };
+
+    let raw_state = serde_json::to_string(&state_dump).unwrap();
+
+    let mut file = File::create(srcpath.to_owned() + "_state_dump.json").unwrap();
     file.write_all(raw_state.as_bytes());
 }
 

--- a/src/json.rs
+++ b/src/json.rs
@@ -201,8 +201,11 @@ pub fn read_config(path: String) -> InternalState  {
     };
 }
 
-pub fn dump_state(internal_state: &InternalState) -> String {
-    serde_json::to_string(&internal_state).unwrap()
+pub fn dump_state(internal_state: &InternalState) {
+    let raw_state = serde_json::to_string(&internal_state).unwrap();
+
+    let mut file = File::create("state_dump.json").unwrap();
+    file.write_all(raw_state.as_bytes());
 }
 
 #[cfg(test)]

--- a/src/json.rs
+++ b/src/json.rs
@@ -135,14 +135,12 @@ fn to_operator(json_op: JsonOperation, labels_mapping: &Vec<(String, usize)>) ->
 fn labels_to_positions(source_code: &Vec<JsonOperation>) -> Vec<(String, usize)> {
     let mut labels : Vec<(String, usize)> = vec!();
 
-    let mut index = 0;
-    for operation in source_code {
+    for (index, operation) in source_code.iter().enumerate() {
         if operation.operation == String::from("label") {
             if let JsonOperand::Label(label_name) = operation.clone().operand.unwrap() {
                 labels.push((label_name, index));
             }
         }
-        index += 1;
     }
 
    return labels;

--- a/src/json.rs
+++ b/src/json.rs
@@ -201,6 +201,10 @@ pub fn read_config(path: String) -> InternalState  {
     };
 }
 
+pub fn dump_state(internal_state: &InternalState) -> String {
+    serde_json::to_string(&internal_state).unwrap()
+}
+
 #[cfg(test)]
 mod test {
     use Operation;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate serde_derive;
 extern crate serde;
 extern crate serde_json;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Serialize, Debug, Clone, Copy)]
 pub enum Value {
 	Number{value: i32},
 	Character{value: char}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,16 +8,16 @@ use clap::{Arg, App};
 fn main() {
     let app_data = App::new("hrm-interpreter")
                   .version("0.1")
-		  .arg(Arg::with_name("code")
-		       .short("c")
-		       .long("code")
-		       .value_name("CODE")
-		       .takes_value(true))
-		  .arg(Arg::with_name("input")
-		       .short("i")
-		       .long("input")
-		       .value_name("INPUT")
-		       .takes_value(true));
+      .arg(Arg::with_name("code")
+            .short("c")
+            .long("code")
+            .value_name("CODE")
+            .takes_value(true))
+       .arg(Arg::with_name("input")
+            .short("i")
+            .long("input")
+            .value_name("INPUT")
+            .takes_value(true));
 
     let matches = app_data.get_matches();
     let srcpath = matches.value_of("code").unwrap();
@@ -27,29 +27,29 @@ fn main() {
     // create the state to be modified
     let mut internal_state = read_config(String::from(inputpath));
 
-		let mut errored = false;
-		let mut reason = String::new();
-		{
-			let code_execution = CodeIterator::new(&mut internal_state, code);
+    let mut errored = false;
+    let mut reason = String::new();
+    {
+        let code_execution = CodeIterator::new(&mut internal_state, code);
 
-			for operation_result in code_execution {
-				if operation_result.is_err() {
-					errored = true;
-					reason = operation_result.err().unwrap();
-					break;
-				}
-			}
-		}
+        for operation_result in code_execution {
+            if operation_result.is_err() {
+                errored = true;
+                reason = operation_result.err().unwrap();
+                break;
+            }
+        }
+    }
 
-		if errored {
-			println!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
-			println!("Error: {}", reason);
-			println!("Dumping current internal state:");
-			println!("{:?}", internal_state);
-		}
-		else {
-			println!("{:?}", internal_state);
-		}
+    if errored {
+        println!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+        println!("Error: {}", reason);
+        println!("Dumping current internal state:");
+        println!("{:?}", internal_state);
+    }
+    else {
+        println!("{:?}", internal_state);
+    }
 
-		dump_state(&internal_state);
+    dump_state(&internal_state);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,5 +51,5 @@ fn main() {
         println!("{:?}", internal_state);
     }
 
-    dump_state(&internal_state);
+    dump_state(&internal_state, srcpath, reason);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 extern crate clap;
 
 extern crate hrm_interpreter;
-use hrm_interpreter::json::{read_file, read_config};
+use hrm_interpreter::json::{read_file, read_config, dump_state};
 use hrm_interpreter::CodeIterator;
 use clap::{Arg, App};
 
@@ -50,4 +50,6 @@ fn main() {
 		else {
 			println!("{:?}", internal_state);
 		}
+
+		dump_state(&internal_state);
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,8 +2,9 @@ use Value;
 use Operation;
 use operators;
 use operators::Operator;
+use serde_json;
 
-#[derive(Debug, Clone)]
+#[derive(Serialize, Debug, Clone)]
 pub struct InternalState {
   pub register: Option<Value>,
 	pub input_tape: Vec<Value>,


### PR DESCRIPTION
this change will help when we'll implement automated testing/comparison of hrm-compiler